### PR TITLE
Background bgrfb process

### DIFF
--- a/flaskr-tdd/project/static/main.js
+++ b/flaskr-tdd/project/static/main.js
@@ -8,7 +8,9 @@
     postElements[i].addEventListener("click", function () {
       const postId = this.getElementsByTagName("h2")[0].getAttribute("id");
       const node = this;
-      fetch(`/delete/${postId}`)
+      fetch(`/delete/${postId}`, {
+        method: 'POST'
+      })
         .then(function (resp) {
           return resp.json();
         })

--- a/flaskr-tdd/tests/app_test.py
+++ b/flaskr-tdd/tests/app_test.py
@@ -79,6 +79,15 @@ def test_messages(client):
 
 def test_delete_message(client):
     """Ensure the messages are being deleted"""
-    rv = client.get("/delete/1")
+    # First, login
+    login(client, app.config["USERNAME"], app.config["PASSWORD"])
+    # Add a message
+    client.post(
+        "/add",
+        data=dict(title="Test Post", text="Test content"),
+        follow_redirects=True,
+    )
+    # Now delete it
+    rv = client.post("/delete/1")
     data = json.loads(rv.data)
     assert data["status"] == 1


### PR DESCRIPTION
Fix delete functionality by updating frontend and test to use POST requests for the delete route.

The Flask `/delete/<int:post_id>` route is configured to only accept POST requests. Both the `test_delete_message` and the `main.js` frontend code were incorrectly sending GET requests, leading to a 405 Method Not Allowed error and preventing deletion. The test was also updated to include proper setup (login and creating a post) for a more robust test.

---
<a href="https://cursor.com/background-agent?bcId=bc-e10d7bcc-c85c-4984-965f-cd65e99694d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e10d7bcc-c85c-4984-965f-cd65e99694d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

